### PR TITLE
Added syncable tabs issue #10

### DIFF
--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
@@ -1,7 +1,7 @@
 ﻿(function () {
     'use strict';
 
-    function tabbedContentDirective($timeout) {
+    function tabbedContentDirective($timeout, eventsService) {
 
         function link($scope, $element, $attrs) {
 

--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.html
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.html
@@ -1,49 +1,55 @@
 ﻿<div>
     <ng-form name="tabbedContentForm">
-        <ul class="matryoshka-tabs-list umb-tabs-nav" ng-if="content.tabs.length > 1">
-            <li class="matryoshka-tab-link umb-tab" 
-              data-element="tab-{{group.label}}" 
-              matryoshka-val-tab="" 
-              id="tab{{group.label}}" 
-              ng-class="{'active' : currentTab === group.label, 'hasError' : tabHasError}" 
-              ng-repeat="group in content.tabs | limitTo: maxTabs" >
-                <p>
-                    <i class="icon icon-alert"></i>
-                    <span>{{group.label}}</span>
-                </p>
-                <button class="btn-reset matryoshka-tab-link-button" ng-click="changeTab(group.label)" type="button" role="tab"></button>
-                <umb-dropdown class="matryoshka-tab-dropdown" ng-if="groupSeparators[group.label] && groupSeparators[group.label].length > 0">
-                    <umb-dropdown-item ng-repeat="separator in groupSeparators[group.label]">
-                        <button class="btn-reset umb-tab-button" ng-click="scrollTo(group.label, separator.alias)" role="tab" type="button">
-                            <p>
-                                <span>{{separator.label}}</span>
-                            </p>
-                        </button>
-                    </umb-dropdown-item>
-                </umb-dropdown>
-            </li>
-  
-            <li data-element="tab-expand" class="umb-tab umb-tab--expand" ng-class="{ 'open': showTray }" ng-show="needTray">
-                <a class="btn-reset umb-tab-button umb-tab-button--expand" ng-click="toggleTray()" type="button">
-                    <i></i><i></i><i></i>
-                    <span class="sr-only"><localize key="visuallyHiddenTexts_tabExpand">View more options</localize></span>
-                </a>
-                <umb-dropdown class="umb-tabs-tray" ng-if="showTray" on-close="vm.hideTray()">
-                    <umb-dropdown-item ng-repeat="group in content.tabs | limitTo: overflowingTabs" ng-class="{'umb-tabs-tray-item--active': tab.active, 'hasError' : tabHasError}">
-                        <button class="btn-reset umb-tab-button" matryoshka-val-tab="" ng-click="changeTab(group.label)" role="tab" aria-selected="{currentTab === group.label}" type="button">
-                          <p>
-                            <i class="icon icon-alert"></i>
-                            <span>{{group.label}}</span>
-                          </p>
-                        </button>
-                    </umb-dropdown-item>
-                </umb-dropdown>
-            </li>
-        </ul>
+        <div class="matryoshka-tabs-list-wrapper umb-tabs-nav">
+            <ul class="matryoshka-tabs-list" ng-if="content.tabs.length > 1">
+                <li class="matryoshka-tab-link umb-tab"
+                    data-element="tab-{{group.label}}"
+                    matryoshka-val-tab=""
+                    id="tab{{group.label}}"
+                    ng-class="{'active' : currentTab === group.label, 'hasError' : tabHasError}"
+                    ng-repeat="group in content.tabs | limitTo: maxTabs">
+                    <p>
+                        <i class="icon icon-alert"></i>
+                        <span>{{group.label}}</span>
+                    </p>
+                    <button class="btn-reset matryoshka-tab-link-button" ng-click="changeTab(group.label)" type="button" role="tab"></button>
+                    <umb-dropdown class="matryoshka-tab-dropdown" ng-if="groupSeparators[group.label] && groupSeparators[group.label].length > 0">
+                        <umb-dropdown-item ng-repeat="separator in groupSeparators[group.label]">
+                            <button class="btn-reset umb-tab-button" ng-click="scrollTo(group.label, separator.alias)" role="tab" type="button">
+                                <p>
+                                    <span>{{separator.label}}</span>
+                                </p>
+                            </button>
+                        </umb-dropdown-item>
+                    </umb-dropdown>
+                </li>
+
+                <li data-element="tab-expand" class="umb-tab umb-tab--expand" ng-class="{ 'open': showTray }" ng-show="needTray">
+                    <a class="btn-reset umb-tab-button umb-tab-button--expand" ng-click="toggleTray()" type="button">
+                        <i></i><i></i><i></i>
+                        <span class="sr-only"><localize key="visuallyHiddenTexts_tabExpand">View more options</localize></span>
+                    </a>
+                    <umb-dropdown class="umb-tabs-tray" ng-if="showTray" on-close="vm.hideTray()">
+                        <umb-dropdown-item ng-repeat="group in content.tabs | limitTo: overflowingTabs" ng-class="{'umb-tabs-tray-item--active': tab.active, 'hasError' : tabHasError}">
+                            <button class="btn-reset umb-tab-button" matryoshka-val-tab="" ng-click="changeTab(group.label)" role="tab" aria-selected="{currentTab === group.label}" type="button">
+                                <p>
+                                    <i class="icon icon-alert"></i>
+                                    <span>{{group.label}}</span>
+                                </p>
+                            </button>
+                        </umb-dropdown-item>
+                    </umb-dropdown>
+                </li>
+            </ul>
+            <button type="button" aria-label="Sync-tabs" ng-if="splitview" ng-click="toggleSync()" class="matryoshka-tabs-syncbutton">
+                <i ng-if="syncTabs" class="icon-lock" aria-hidden="true"></i>
+                <i ng-if="!syncTabs" class="icon-unlocked -unlocked" aria-hidden="true"></i>
+            </button>
+        </div>
         <div class="matryoshka-tabbed-content-push" ng-if="content.tabs.length > 1"></div>
-  
+
         <div class="umb-group-panel" data-element="group-{{group.alias}}" ng-repeat="group in content.tabs track by group.label">
-  
+
             <div class="umb-group-panel__content matryoshka-tabbed-panel matryoshka-tab-content-{{group.alias}}" ng-hide="hide(group.label)" id="{{group.label}}">
                 <umb-property data-element="property-{{property.alias}}"
                               ng-repeat="property in group.properties track by property.alias"

--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
@@ -1,12 +1,28 @@
+.matryoshka-tabs-list-wrapper {
+    position: sticky;
+    top: 0;
+    width: 100%;
+    margin: -20px 0 0 -20px;
+    background: #fff;
+    padding: 0 20px;
+    z-index: 6;
+}
+
+.matryoshka-tabs-syncbutton {
+    background: none;
+    border: none;
+    position: absolute;
+    display: block;
+    top: 0;
+    right: 0;
+    top: 20px;
+    z-index: 7;
+    padding: 0 3px;
+}
 
 .matryoshka-tabs-list {
-    margin: -20px 0 0 -20px;
-    position: sticky;
-    top:0;
-    z-index: 6;
-    background: #fff;
-    width: 100%;
-    padding:0 20px;
+    margin: 0;
+    padding:0;
 }
 
 .matryoshka-tabs-list ~ .umb-group-panel {


### PR DESCRIPTION
Tabs are now synchronized while in split views.

Since the splitview feature is designed to compare content I've chosen to sync the tabs by default. The lock in the left screen toggles if sync is active.
Also I've added the sync on the scrollto when you select a separator from a tab dropdown.

I've tested this against 8.8 but there shouldn't be a reason why it wouldn't work on earlier versions.

Please let me know if you like anything to be changed.