### PR TITLE
Removing mysterious space from above tabbed content

### DIFF
--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.html
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.html
@@ -1,5 +1,5 @@
 ﻿<div>
-    <ng-form name="tabbedContentForm">
+    <ng-form name="tabbedContentForm" class="matryoshka-tabbed-content">
         <div class="matryoshka-tabs-list-wrapper umb-tabs-nav">
             <ul class="matryoshka-tabs-list" ng-if="content.tabs.length > 1">
                 <li class="matryoshka-tab-link umb-tab"

--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
@@ -1,3 +1,7 @@
+.matryoshka-tabbed-content .umb-group-panel {
+    margin-bottom: 0;
+}
+
 .matryoshka-tabs-list-wrapper {
     position: sticky;
     top: 0;


### PR DESCRIPTION
I'm using the Matryoshka package on a few complex sites and loving it!

One thing has been bugging me, and that's a mysterious space above secondary tabs in the tabbed view (first tab is fine).

First tab:

<img width="1680" alt="Screenshot 2020-10-14 at 13 13 30" src="https://user-images.githubusercontent.com/16511093/95987437-56533200-0e1f-11eb-90a5-80edbd89aa72.png">

Second tab:

<img width="1680" alt="Screenshot 2020-10-14 at 13 13 16" src="https://user-images.githubusercontent.com/16511093/95987476-63702100-0e1f-11eb-8a71-71085b272a63.png">

This is because Umbraco applies a `margin-bottom` of 20px between each group. This change removes this for Matryoshka's tabbed view:

<img width="1679" alt="Screenshot 2020-10-14 at 13 14 08" src="https://user-images.githubusercontent.com/16511093/95987566-84387680-0e1f-11eb-9c39-acf4babc643b.png">