### PR TITLE
Add compatibility for native Umbraco tabs

### DIFF
--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/directives/matryoshka-tabbed-content.directive.js
@@ -4,6 +4,10 @@
     function tabbedContentDirective($timeout, eventsService) {
 
         function link($scope, $element, $attrs) {
+            // Filter out native tabs without properties
+            $scope.content.tabs = $scope.content.tabs.filter(function (tab) {
+                return !tab.type || tab.type === 0 || tab.properties.length > 0;
+            });
 
             var appRootNode = $element[0];
             $scope.currentTab = "";

--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
@@ -1,3 +1,8 @@
+/* Disable adding native tabs while package is installed */
+.umb-group-builder__tabs [data-element='tab-add'] {
+    display: none;
+}
+
 .matryoshka-tabbed-content .umb-group-panel {
     margin-bottom: 0;
 }

--- a/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
+++ b/src/Our.Umbraco.Matryoshka/App_Plugins/Our.Umbraco.Matryoshka/tabbed-content.css
@@ -1,5 +1,6 @@
 /* Disable adding native tabs while package is installed */
-.umb-group-builder__tabs [data-element='tab-add'] {
+.umb-group-builder__tabs-list__add-tab,
+.umb-group-builder__convert-dropzone {
     display: none;
 }
 


### PR DESCRIPTION
While working on bringing tabs back to Umbraco natively (see PR https://github.com/umbraco/Umbraco-CMS/pull/10606), I've tested what happens in combination with Matryoshka: property groups are still shown as tabs and the group separator editor works the same 🎉

Because the property groups are already shown as tabs, adding native tabs to a document, media or member type does not make sense: to prevent this, I've hidden the `Add tab` button using CSS. So as long as this package is installed, you can't add native tabs from the back-office UI (at least not easily).

It's still possible to end up with native tabs though, e.g. because you imported a document type with tabs, you installed an Umbraco package or maybe even configured them before installing this package. To support this, I've filtered the tabs/groups to only show property groups (or the absence of the `type` property for backwards compatibility) - no matter on which tab they are added, if any. The only edge-case when a native tab is shown, is when it directly contains properties...

~I've created this as a draft PR, because it still needs to be tested on older Umbraco versions (for backwards compatibility) and the linked PR is also still a draft.~